### PR TITLE
Add LLM_RETRY_COUNT and increase max_output_tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ CV Evaluator sends a CV to an LLM for review. A CodeYourFuture project.
    
    # Environment (use 'development' for local, 'production' for deployed)
    ENVIRONMENT=development
+
+   # LLM retry count (0 = no retries, max 3)
+   LLM_RETRY_COUNT=2
    ```
 
 5. Update `app/llm_evaluator.yml` with your desired LLM configuration (model, reasoning level, etc.).
@@ -111,6 +114,7 @@ This application uses GitHub OAuth for authentication. Only members of the confi
 | `ALLOWED_ORG` | GitHub org name users must belong to | `CodeYourFuture` |
 | `APP_URL` | Public URL of the application | `https://example.com` |
 | `ENVIRONMENT` | `development` or `production` | `production` |
+| `LLM_RETRY_COUNT` | Number of times to retry LLM evaluation on failure (0 = no retries, max 3) | `2` |
 
 ### Authentication Flow
 
@@ -152,6 +156,7 @@ sudo docker run -ti --rm \
   -e ALLOWED_ORG=CodeYourFuture \
   -e APP_URL=http://localhost:8000 \
   -e ENVIRONMENT=development \
+  -e LLM_RETRY_COUNT=2 \
   --name cyf-cv-evaluator -p 8000:8000 cyf-cv-evaluator
 ```
 
@@ -206,4 +211,5 @@ sudo docker compose up -d
    - `ALLOWED_ORG` (e.g. `CodeYourFuture`)
    - `APP_URL` (set to your Coolify domain, e.g. `https://my-server.example.com` with No trailing slash)
    - `ENVIRONMENT` (set to `production` for secure cookies and CORS)
+   - `LLM_RETRY_COUNT` (set to the number of times to retry LLM evaluation on failure, 0 = no retries, max 3)
 7. Deploy the application.

--- a/app/config.py
+++ b/app/config.py
@@ -38,6 +38,9 @@ class Settings(BaseSettings):
     # Application URL (for OAuth callback)
     app_url: str = Field(default="http://localhost:8000", alias="APP_URL")
     
+    # LLM retry count (0 = no retries, max 3)
+    llm_retry_count: int = Field(default=0, alias="LLM_RETRY_COUNT", ge=0, le=3)
+
     # Environment
     environment: str = Field(default="development", alias="ENVIRONMENT")
     

--- a/app/llm_evaluator.yml
+++ b/app/llm_evaluator.yml
@@ -1,6 +1,6 @@
 model: 'gpt-5-mini'
 reasoning: 'medium'
-max_output_tokens: 8192
+max_output_tokens: 32768
 
 system_message: |
   You are an evaluator of UK-based curriculum vitae for aspiring or junior software engineers. The CVs are to be in specific format with specific content expectations. 

--- a/app/main.py
+++ b/app/main.py
@@ -118,11 +118,18 @@ async def evaluate_cv(
             raise HTTPException(status_code=400, detail=f"Error reading file: {str(e)}")
     
     # Evaluate the CV using the LLM evaluator
-    try:
-        result = await evaluator.eval(cv_content)
-        return result
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error evaluating CV: {str(e)}")
+    last_exc: Exception | None = None
+    for attempt in range(1 + settings.llm_retry_count):
+        try:
+            result = await evaluator.eval(cv_content)
+            return result
+        except Exception as e:
+            last_exc = e
+            if attempt < settings.llm_retry_count:
+                logger.warning(f"CV evaluation attempt {attempt + 1} of {1 + settings.llm_retry_count} failed, retrying...")
+            else:
+                logger.error(f"CV evaluation failed after {1 + settings.llm_retry_count} attempts.")
+    raise HTTPException(status_code=500, detail=f"Error evaluating CV: {str(last_exc)}")
 
 # Mount the API app under the /api path
 app.mount("/api", api_app)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,3 +18,5 @@ services:
       - 'APP_URL=https://example.com'
       # Environment (production enables secure cookies and restricted CORS)
       - 'ENVIRONMENT=production'
+      # LLM retry count (0 = no retries, max 3)
+      - 'LLM_RETRY_COUNT=2'


### PR DESCRIPTION
This pull request introduces a configurable retry mechanism for LLM (Large Language Model) evaluation failures, allowing the application to automatically retry failed LLM requests up to a specified number of times. It also increases the maximum output tokens for the LLM model, and updates documentation and configuration files to reflect these changes.

**LLM Retry Mechanism:**

* Added a new environment variable `LLM_RETRY_COUNT` (range 0–3) to control the number of automatic retries for LLM evaluation failures, with updates to documentation (`README.md`), application settings (`app/config.py`), Docker configuration (`docker-compose.yaml`), and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R214) [[5]](diffhunk://#diff-84f1a9419471e289c6b6e2b0209b329e20df6cef81d1f7f0a193ddc2fc6ad69dR41-R43) [[6]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R21-R22)
* Updated the CV evaluation endpoint to implement retry logic based on `LLM_RETRY_COUNT`, logging each retry and returning an error only after all retries fail.

**LLM Model Configuration:**

* Increased the `max_output_tokens` for the LLM model from 8192 to 32768 in `app/llm_evaluator.yml`, allowing for longer responses.